### PR TITLE
feat: let the router set the ready GPIO pin after startup

### DIFF
--- a/debian/arduino-router/etc/systemd/system/arduino-router.service
+++ b/debian/arduino-router/etc/systemd/system/arduino-router.service
@@ -7,9 +7,8 @@ Requires=
 [Service]
 # Put the micro in a ready state.
 ExecStartPre=-/usr/bin/gpioset -c /dev/gpiochip1 -t0 37=0
-ExecStart=/usr/bin/arduino-router --unix-port /var/run/arduino-router.sock --serial-port /dev/ttyHS1 --serial-baudrate 115200
-# End the boot animation after the router is started.
-ExecStartPost=/usr/bin/gpioset -c /dev/gpiochip1 -t0 70=1
+# Launch router and end the boot animation after the router is started (--after-start).
+ExecStart=/usr/bin/arduino-router --unix-port /var/run/arduino-router.sock --serial-port /dev/ttyHS1 --serial-baudrate 115200 --after-start "/usr/bin/gpioset -c /dev/gpiochip1 -t0 70=1"
 StandardOutput=journal
 StandardError=journal
 Restart=always


### PR DESCRIPTION
### Motivation

Otherwise, the pin may be set high by systemd before the router is actually ready to process data.

### Change description

* add a `--after-start` flag, that executes the given command when the router is ready
* changes the systemd script to let the router set the GPIO pin

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [X] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [X] Logging is meaningful in case of troubleshooting.
