### PR TITLE
Allow calling internal methods also as notifications

### DIFF
--- a/internal/msgpackrouter/router.go
+++ b/internal/msgpackrouter/router.go
@@ -129,6 +129,13 @@ func (r *Router) connectionLoop(conn io.ReadWriteCloser) {
 			// This handler is called when a notification is received from the client
 			slog.Debug("Received notification", "method", method, "params", params)
 
+			// Check if the method is an internal method
+			if handler, ok := r.routesInternal[method]; ok {
+				// call the internal method handler (since it's a notification, discard the result)
+				_, _ = handler(context.Background(), msgpackconn, params)
+				return
+			}
+
 			// Check if the method is registered
 			client, ok := r.getConnectionForMethod(method)
 			if !ok {


### PR DESCRIPTION
### Motivation

This is mainly required to allow sending messages to the monitor (`mon/write`) using a notification instead of a request. This change should increase the throughput of this debug channel.

### Change description

The router's internal methods, expect `$/register` and `$/reset`, can now be invoked either as Request or as Notification.
If a client opts to use the Notification:
* It will lose the return/error values.
* It will not know when the action has been completed (the notification returns immediately, while a request will wait until the action completes).

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
