### PR TITLE
Add `arduino-firmware-radio` as a dependency

### DIFF
--- a/debian/arduino-router/DEBIAN/control
+++ b/debian/arduino-router/DEBIAN/control
@@ -3,5 +3,5 @@ Version: $VERSION
 Architecture: $ARCH
 Maintainer: arduino <support@arduino.cc>
 Description: Arduino application router
-Depends: socat
+Depends: socat, arduino-firmware-radio
 


### PR DESCRIPTION
### Motivation
Add arduino-radio package as a dependency, so that it will be installed automatically when doing the board updates.
