### PR TITLE
Send `$/start` notification to the serial client upon startup.

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func startRouter(cfg Config) error {
 				wr := &MsgpackDebugStream{Name: cfg.SerialPortAddr, Upstream: serialPort}
 
 				// wait for the close command from RPC or for a failure of the serial port (routerExit)
-				routerExit := router.Accept(wr)
+				routerExit := router.AcceptAndSendNotification(wr)
 				select {
 				case <-routerExit:
 					slog.Info("Serial port failed connection")


### PR DESCRIPTION
### Motivation

Experimental: trying to figure out the best way to signal router readiness to the sketch.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
