### PR TITLE
fix: add missing close

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ func startRouter(cfg Config) error {
 				}
 
 				// in any case, wait for the router to drop the connection
+				wr.Close()
 				serialPort.Close()
 				<-routerExit
 			}


### PR DESCRIPTION
### Motivation

We weren't closing the debugging wrapper, which made the router still attach to a closed readwriter if USB serial disconnect/reconnect.
 
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
