### PR TITLE
feat: start `arduino-router-serial` only if serial available

### DIFF
--- a/debian/arduino-router/DEBIAN/postinst
+++ b/debian/arduino-router/DEBIAN/postinst
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-systemctl enable arduino-router
-systemctl enable arduino-router-serial
+systemctl enable arduino-router.service
+systemctl enable arduino-router-serial.service
+systemctl enable arduino-router-serial.path
 

--- a/debian/arduino-router/DEBIAN/prerm
+++ b/debian/arduino-router/DEBIAN/prerm
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-systemctl disable arduino-router
-systemctl disable arduino-router-serial
+systemctl disable arduino-router.service
+systemctl disable arduino-router-serial.service
+systemctl disable arduino-router-serial.path
 

--- a/debian/arduino-router/etc/systemd/system/arduino-router-serial.path
+++ b/debian/arduino-router/etc/systemd/system/arduino-router-serial.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=Watch for /dev/ttyGS0 to start arduino-router-serial
+
+[Path]
+PathExists=/dev/ttyGS0
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/arduino-router/etc/systemd/system/arduino-router-serial.service
+++ b/debian/arduino-router/etc/systemd/system/arduino-router-serial.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Proxy for the Arduino Router Monitor to ttyGS0 serial
-After=network-online.target arduino-router.service
-Wants=network-online.target arduino-router.service
+After=network.target arduino-router.service adbd.service
+Wants=network.target arduino-router.service
 Requires=arduino-router.service
+ConditionPathExists=/dev/ttyGS0
 
 [Service]
+ExecStartPre=/bin/sleep 2  # make sure adbd created the /dev/ttyGS0 device
 ExecStart=/usr/bin/socat file:/dev/ttyGS0,raw,echo=0,b9600,crtscts=0 tcp:127.0.0.1:7500
 StandardOutput=journal
 StandardError=journal

--- a/debian/arduino-router/etc/systemd/system/arduino-router-serial.service
+++ b/debian/arduino-router/etc/systemd/system/arduino-router-serial.service
@@ -1,12 +1,11 @@
 [Unit]
 Description=Proxy for the Arduino Router Monitor to ttyGS0 serial
-After=network.target arduino-router.service adbd.service
+After=network.target arduino-router.service
 Wants=network.target arduino-router.service
 Requires=arduino-router.service
 ConditionPathExists=/dev/ttyGS0
 
 [Service]
-ExecStartPre=/bin/sleep 2  # make sure adbd created the /dev/ttyGS0 device
 ExecStart=/usr/bin/socat file:/dev/ttyGS0,raw,echo=0,b9600,crtscts=0 tcp:127.0.0.1:7500
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
### Motivation

We need the serial forward to ide2 only if the linux serial is up. If the board is in SBC mode, it will not be available.

### Change description

Use the path trigger for starting socat only in usb mode.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
