### PR TITLE
fix(monza): put micro is in ready state

### DIFF
--- a/debian/arduino-router/var/lib/arduino-router/config/10-monza.conf
+++ b/debian/arduino-router/var/lib/arduino-router/config/10-monza.conf
@@ -3,6 +3,8 @@ ExecStart=
 ExecStart=/usr/bin/arduino-router --unix-port /var/run/arduino-router.sock --serial-port /dev/ttyACM0 --serial-baudrate 115200
 
 # Compatible gpioset 2.x
+# Put the micro in a ready state.
+ExecStartPre=-/usr/bin/gpioset -c2 -t0 47=0
 # End the boot animation after the router is started.
 ExecStartPost=-/usr/bin/gpioset -c2 -t0 95=1
 # Restart the boot aninamtion if the router is stopped.
@@ -11,6 +13,8 @@ ExecStopPost=-/usr/bin/gpioset -c2 -t0 78=0
 ExecStopPost=-/usr/bin/gpioset -c2 -t0 78=1
 
 # Compatible gpioset 1.x
+# Put the micro in a ready state.
+ExecStartPre=-/usr/bin/gpioset 2 47=0
 # End the boot animation after the router is started.
 ExecStartPost=-/usr/bin/gpioset 2 95=1
 # Restart the boot aninamtion if the router is stopped.


### PR DESCRIPTION
### Motivation

Replicate the unoq workaround, which ensures the micro is not in DFU before starting the router.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
