### PR TITLE
fix: remove dependency on arduino-unoq-radio-firmware

### DIFF
--- a/debian/arduino-router/DEBIAN/control
+++ b/debian/arduino-router/DEBIAN/control
@@ -3,5 +3,5 @@ Version: $VERSION
 Architecture: $ARCH
 Maintainer: arduino <support@arduino.cc>
 Description: Arduino application router
-Depends: socat, arduino-unoq-radio-firmware
+Depends: socat
 


### PR DESCRIPTION
### Motivation
The `arduino-unoq-radio-firmware` is now a dependency of the `arduino-unoq` package 

### Change description

<!-- What does your code do? -->

### Additional Notes

Related pr on app-cli https://github.com/arduino/arduino-app-cli/pull/387

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
